### PR TITLE
Refactoring the `conio_lt.h` ⚡

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# CONIO LITE
-**Author  : Ryuu Mitsuki**<br>
-**Version : 0.1.2**<br>
+# conio_lt
+**Author  : Ryuu Mitsuki**  
+**Version : 0.1.5**
 
 ## DESCRIPTION
-`conio_lt.h` is a lite version of `conio.h` for **Linux**.<br>
-And intended only for **Linux** user.<br>
-<img src="https://www.freepnglogos.com/uploads/linux-png/difference-between-linux-and-window-operating-system-3.png" width="200" height="200"/>
+The `conio_lt.h` is a lite version of `conio.h` library for **Linux/Unix**.  
+This library are intended only for **Unix** user and **Borland C++** (which doesn't seem provided the `<conio.h>` library), for **Windows** user also can use it with [Git Bash](https://git-scm.com) as shell environment.  
+> **Note** On **Windows** make sure the [MinGw](https://sourceforge.net/projects/mingw/) already installed.
+<img src="https://www.freepnglogos.com/uploads/linux-png/difference-between-linux-and-window-operating-system-3.png" width="170" height="170"/>
 
 ### Full Version by @zoelabbb
 - [zoelabbb](https://github.com/zoelabbb)
 - [zoelabbb/conio.h](https://github.com/zoelabbb/conio.h.git)
 
 ## LIST METHODS
-- `getch()`
-- `getche()`
-- `ungetch()`
-- `clrscr()`
-- `gotoxy()`
-- `wherex()`
-- `wherey()`
-- `putch()`
-- `putchar()`
-> **Note** This isn't a full version of 'conio.h'.<br>
-> This library has only a few functions that are often used by most programmers.<br>
+- `clrscr()` - Clears the terminal screen.
+- `getch()` - Reads a single character from the standard input.
+- `getche()` - Reads a single character from the standard input and then echoing it.
+- `gotoxy(int, int)` - Moves the cursor to the specified coordinates on the terminal screen.
+- `putch(int)` - Writes a character to the standard output.
+- `ungetch(int)` - Pushes a character back onto the input stream.
+- `wherex()` - Retrieves the current X-coordinate of the cursor on the terminal screen.
+- `wherey()` - Retrieves the current Y-coordinate of the cursor on the terminal screen.
+> **Note** This isn't a full version of 'conio.h'.  
+> This library has only a few functions that are often used by most programmers.
 
 ## INSTALLATION
-### Install the requirements
+### Install the requirements (Unix system only)
 ```bash
 pkg update && pkg upgrade
 ```
@@ -37,15 +37,19 @@ pkg install clang git -y
 git clone https://github.com/mitsuki31/conio_lt.git
 ```
 
+Or you can also download the archived version on the [release](https://github.com/mitsuki31/conio_lt/releases/latest).
+
 ### Install as root
 > **Warning** Must have an `Administrator` or `root` privileges:warning:
 ```bash
-cp conio_lt/conio_lt.h $HOME/usr/include
+cp conio_lt/conio_lt.h /usr/include
 ```
-> **Note** Each devices can be different, on my device is `$HOME/usr/include`
+> **Note** This installation only for **Unix** system.  
+> To install it for **Borland C++**, copy it to where the **Borland C++** would searches its libraries.
+> It depends on where you installed the **Borland C++**.
 
 ### Install as local
 ```bash
-cp conio_lt/conio_lt.h <path_to_your_project>
+cp conio_lt/conio_lt.h "path/to/your_project"
 ```
-> **Note** Change `<path_to_your_directory>` to your project directory<br>
+> **Note** Change `"path/to/your_project"` to your project directory.

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -150,4 +150,19 @@ const void clrscr() {
     printf("%s0m%s1J%s1;1f", __prefix, __prefix, __prefix);
 }
 
+/**
+ * @brief Pushes a character back onto the input stream.
+ * This function pushes a character back onto the input stream.
+ * It takes an integer parameter \c __c, representing the character to be pushed back.
+ *
+ * @param  __c  The character to be pushed back.
+ *
+ * @return      Returns the pushed-back character on success, or `EOF` on failure.
+ *
+ * @since       0.1.0
+ */
+const int ungetch(const int __c) {
+   return ungetc(__c, stdin);
+}
+
 #endif /* CONIO_LT_H_ */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -128,4 +128,26 @@ const void gotoxy(const int __x, const int __y) {
     printf("%s%d;%df", __prefix, __y, __x);
 }
 
+/**
+ * @brief Clears the terminal screen.
+ * This function clears the terminal screen by sending control sequences
+ * to the standard output using \c printf.
+ *
+ * <p>The function uses the following control sequences:
+ *
+ * <ul>
+ *   <li> \c "\033[0m": Resets any text formatting or color attributes.
+ *   <li> \c "\033[1J": Clears the screen from the cursor position to the end of the screen.
+ *   <li> \c "\033[1;1f": Moves the cursor to the top-left corner of the screen.
+ * </ul>
+ *
+ * <p>By combining these control sequences in a single \c printf statement,
+ * the function achieves the effect of clearing the terminal screen.
+ *
+ * @since 0.1.0
+ */
+const void clrscr() {
+    printf("%s0m%s1J%s1;1f", __prefix, __prefix, __prefix);
+}
+
 #endif /* CONIO_LT_H_ */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -225,4 +225,20 @@ const int wherey() {
     return __y;  /* only return the Y-coordinate */
 }
 
+/**
+ * @brief Writes a character to the standard output.
+ * This function writes a character to the standard output.
+ * It takes an integer parameter \c __chr, representing the character to be written.
+ *
+ * @param  __chr  The character to be written.
+ *
+ * @return        Returns the written character as an integer.
+ *
+ * @since         0.1.0
+ */
+const int putchar(const int __chr) {
+    printf("%c", __chr);
+    return (int) __chr;
+}
+
 #endif /* CONIO_LT_H_ */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -10,23 +10,21 @@
  * -------------
  * Similar like 'conio.h', but it's a lite version of 'conio.h'.
  * I hope this can be useful for your project or something else.
- *
- * Made with : Termux
- * OS type   : Android (aarch64-linux)
- * Clang ver : 15.0.7
  * ------------
  *
  * List Functions
  * --------------
- * :>  getch()
- * :>  getche()
- * :>  ungetch()
- * :>  clrscr()
- * :>  gotoxy()
- * :>  wherex()
- * :>  wherey()
- * :>  putch()
- * :>  putchar()
+ * <ul>
+ *   <li> getch()
+ *   <li> getche()
+ *   <li> ungetch()
+ *   <li> clrscr()
+ *   <li> gotoxy()
+ *   <li> wherex()
+ *   <li> wherey()
+ *   <li> putch()
+ *   <li> putchar()
+ * </ul>
  * --------------
  *
  */
@@ -112,6 +110,22 @@ static const void __whereis_xy(int &__x, int &__y) {
     /* Store and assign the cursor position */
     __x = x;
     __y = y;
+}
+
+
+
+/**
+ * @brief Moves the cursor to the specified coordinates on the terminal screen.
+ * This function moves the cursor on the terminal screen to the specified coordinates.
+ * It takes two integer parameters, \c __x and \c __y, representing the X and Y coordinates respectively.
+ *
+ * @param __x  The X-coordinate to move the cursor to.
+ * @param __y  The Y-coordinate to move the cursor to.
+ *
+ * @since      0.1.0
+ */
+const void gotoxy(const int __x, const int __y) {
+    printf("%s%d;%df", __prefix, __y, __x);
 }
 
 #endif /* CONIO_LT_H_ */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -195,4 +195,34 @@ const int getche() {
     return __getch(1);  /* non-zero means with echo */
 }
 
+/**
+ * @brief Retrieves the current X-coordinate of the cursor on the terminal screen.
+ * This function retrieves the current X-coordinate of the cursor on the terminal screen.
+ *
+ * @return Returns the X-coordinate of the cursor.
+ *
+ * @since  0.1.0
+ */
+const int wherex() {
+    int __x = 0, __y = 0;
+    __whereis_xy(&__x, &__y);
+
+    return __x;  /* only return the X-coordinate */
+}
+
+/**
+ * @brief Retrieves the current Y-coordinate of the cursor on the terminal screen.
+ * This function retrieves the current Y-coordinate of the cursor on the terminal screen.
+ *
+ * @return Returns the Y-coordinate of the cursor.
+ *
+ * @since  0.1.0
+ */
+const int wherey() {
+    int __x = 0, __y = 0;
+    __whereis_xy(&__x, &__y);
+
+    return __y;  /* only return the Y-coordinate */
+}
+
 #endif /* CONIO_LT_H_ */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -162,7 +162,19 @@ const void clrscr() {
  * @since       0.1.0
  */
 const int ungetch(const int __c) {
-   return ungetc(__c, stdin);
+    return ungetc(__c, stdin);
+}
+
+/**
+ * @brief Reads a single character from the standard input without echoing it.
+ * This function reads a single character from the standard input without echoing it.
+ *
+ * @return Returns the character read from the standard input.
+ *
+ * @since  0.1.0
+ */
+const int getch() {
+    return __getch(0);  /* 0 means no echo */
 }
 
 #endif /* CONIO_LT_H_ */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -1,35 +1,38 @@
-/*
+/**
+ * @file conio_lt.h
+ *
+ * Copyright (c) 2023 Ryuu Mitsuki
+ * Authored and developed by Ryuu Mitsuki
+ *
+ * @version  0.1.5, 2 July 2023
+ *
+ * Description
+ * -------------
+ * Similar like 'conio.h', but it's a lite version of 'conio.h'.
+ * I hope this can be useful for your project or something else.
+ *
+ * Made with : Termux
+ * OS type   : Android (aarch64-linux)
+ * Clang ver : 15.0.7
+ * ------------
+ *
+ * List Functions
+ * --------------
+ * :>  getch()
+ * :>  getche()
+ * :>  ungetch()
+ * :>  clrscr()
+ * :>  gotoxy()
+ * :>  wherex()
+ * :>  wherey()
+ * :>  putch()
+ * :>  putchar()
+ * --------------
+ *
+ */
 
-[======== conio_lt.h ========]
-[ Author  : Ryuu Mitsuki     ]
-[ Version : 0.1.2            ]
-[============================]
-
-Description
--------------
-* Similar like 'conio.h', but it's a lite version of 'conio.h'.
-* I hope this can be useful for your project or something else.
-*
-* Made with : Termux
-* OS type   : Android (aarch64-linux)
-* Clang ver : 15.0.7
-------------
-
-List Functions
---------------
-:>  getch()
-:>  getche()
-:>  ungetch()
-:>  clrscr()
-:>  gotoxy()
-:>  wherex()
-:>  wherey()
-:>  putch()
-:>  putchar()
---------------
-
-*/
-
+#ifndef CONIO_LT_H_
+#define CONIO_LT_H_
 
 
 #include <stdio.h>
@@ -37,134 +40,78 @@ List Functions
 #include <fcntl.h>
 #include <termios.h>
 
-#ifndef __CONIO_LITE_H__
-#define __CONIO_LITE_H__
+static const char* __prefix = "\033[";
 
-class __CONIO_LT {
-    private:
-        const char* __prefix = "\033[";
+/**
+ * @brief Reads a single character from the standard input with optional echo.
+ * This function reads a single character from the standard input, allowing
+ * for optional echo of the input character.
+ * It uses the \c <termios.h> header and the \c tcgetattr and \c tcsetattr functions to modify the terminal settings.
+ *
+ * @param  __echo  A flag indicating whether to echo the input character
+ *                 (non-zero value for echo, 0 for no echo).
+ *
+ * @return         Returns the character read from the standard input.
+ *                 Please note, this function returns the character as integer value.
+ *
+ * @since          0.1.0
+ */
+static const int __getch(unsigned int __echo) {
+    struct termios __oldt, __newt;
+    int __c;
 
-        const int __getch(const bool __echo) {
-            struct termios __oldt, __newt;
-            int __c;
+    tcgetattr(STDIN_FILENO, &__oldt);
+    __newt = __oldt;
+    __newt.c_lflag &= ~ICANON;
 
-            tcgetattr(STDIN_FILENO, &__oldt);
-            __newt = __oldt;
-            __newt.c_lflag &= ~ICANON;
+    if (__echo != 0) {
+        __newt.c_lflag &= ECHO;
+    } else {
+        __newt.c_lflag &= ~ECHO;
+    }
 
-            if(__echo) {
-                __newt.c_lflag &= ECHO;
-            } else {
-                __newt.c_lflag &= ~ECHO;
-            }
+    tcsetattr(STDIN_FILENO, TCSANOW, &__newt);
+    __c = getchar();
+    tcsetattr(STDIN_FILENO, TCSANOW, &__oldt);
 
-            tcsetattr(STDIN_FILENO, TCSANOW, &__newt);
-            __c = getchar();
-            tcsetattr(STDIN_FILENO, TCSANOW, &__oldt);
+    return __c;
+}
 
-            return __c;
-        }
+/**
+ * @brief Retrieves the current cursor position on the terminal screen.
+ * This function retrieves the current cursor position on the terminal screen.
+ * It takes two integer references, __x and __y, as output parameters to store
+ * the X and Y coordinates of the cursor, respectively.
+ *
+ * @param[out] __x  A reference to an integer to store the X-coordinate of the cursor.
+ * @param[out] __y  A reference to an integer to store the Y-coordinate of the cursor.
+ *
+ * @since           0.1.0
+ */
+static const void __whereis_xy(int &__x, int &__y) {
+    int in, x = 0, y = 0;
+    printf("%s6n", __prefix);
 
-        const void __whereis_xy(int &__x, int &__y) {
-            int in, x = 0, y = 0;
-            printf("%s6n", __prefix);
-            if(getch() != '\x1B') {
-                return;
-            }
-            else if(getch() != '\x5B') {
-                return;
-            }
+    /* If the character does not same as '\x1b' nor '\x5b',
+     * immediately return and leaving the __x and __y references unchanged
+     */
+    if (__getch(0) != '\x1B') {
+        return;
+    } else if (__getch(0) != '\x5B') {
+        return;
+    }
 
-            while((in = getch()) != ';') {
-                y = y * 10 + in - '0';
-            }
-            while((in = getch()) != 'R') {
-                x = x * 10 + in - '0';
-            }
+    while ((in = __getch(0)) != ';') {
+        y = y * 10 + in - '0';
+    }
 
-            __x = x;
-            __y = y;
-        }
+    while ((in = __getch(0)) != 'R') {
+        x = x * 10 + in - '0';
+    }
 
-    public:
-        // :: Constructor
-        __CONIO_LT() { }
+    /* Store and assign the cursor position */
+    __x = x;
+    __y = y;
+}
 
-        // :: Destructor
-        ~__CONIO_LT() {
-            printf("%sm", __prefix);
-        }
-
-        // :: gotoxy(x, y) -> void
-        const void gotoxy(const int __x, const int __y) {
-            printf("%s%d;%df", __prefix, __y, __x);
-        }
-
-        // :: clrscr() -> void
-        const void clrscr() {
-            /*
-            * "\033[1J" = clear entire screen permanently (cannot scrolled to up)
-            * "\033[2J" = clear entire screen but can be scrolled to up
-            */
-            printf("%s0m%s1J%s1;1f", __prefix, __prefix, __prefix);
-        }
-
-        // :: ungetch(char) -> int
-        const int ungetch(const int __c) {
-           return ungetc(__c, stdin);
-        }
-
-        // :: getch() -> int
-        const int getch() {
-            int __c;
-            __c = this->__getch(false);
-
-            return __c;
-        }
-
-        // :: getche() -> int
-        const int getche() {
-            int __c;
-            __c = this->__getch(true);
-
-            return __c;
-        }
-
-        // :: wherex() -> int
-        const int wherex() {
-            int __x = 0, __y = 0;
-            this->__whereis_xy(__x, __y);
-
-            /* only return x value */
-            return __x;
-        }
-
-        // :: wherey() -> int
-        const int wherey() {
-            int __x = 0, __y = 0;
-            this->__whereis_xy(__x, __y);
-
-            /* only return y value */
-            return __y;
-        }
-
-        // :: putchar() & putch() -> int
-        const int putchar(const int __char) {
-            printf("%c", __char);
-            return (int)__char;
-        }
-} __CONIO_LT;
-
-
-
-#define gotoxy    __CONIO_LT.gotoxy
-#define clrscr    __CONIO_LT.clrscr
-#define ungetch   __CONIO_LT.ungetch
-#define getch     __CONIO_LT.getch
-#define getche    __CONIO_LT.getche
-#define wherex    __CONIO_LT.wherex
-#define wherey    __CONIO_LT.wherey
-#define putch     __CONIO_LT.putchar
-#define putchar   __CONIO_LT.putch
-
-#endif // __CONIO_LITE_H__
+#endif /* CONIO_LT_H_ */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -15,15 +15,14 @@
  * List Functions
  * --------------
  * <ul>
- *   <li> getch()
- *   <li> getche()
- *   <li> ungetch()
- *   <li> clrscr()
- *   <li> gotoxy()
- *   <li> wherex()
- *   <li> wherey()
- *   <li> putch()
- *   <li> putchar()
+ *   <li> #clrscr()
+ *   <li> #getch()
+ *   <li> #getche()
+ *   <li> #gotoxy(int, int)
+ *   <li> #putch(int)
+ *   <li> #ungetch(int)
+ *   <li> #wherex()
+ *   <li> #wherey()
  * </ul>
  * --------------
  *
@@ -236,9 +235,9 @@ const int wherey() {
  *
  * @since         0.1.0
  */
-const int putchar(const int __chr) {
+const int putch(const int __chr) {
     printf("%c", __chr);
-    return (int) __chr;
+    return __chr;
 }
 
 #endif /* CONIO_LT_H_ */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -86,7 +86,7 @@ static const int __getch(unsigned int __echo) {
  *
  * @since           0.1.0
  */
-static const void __whereis_xy(int &__x, int &__y) {
+static void __whereis_xy(int *__x, int *__y) {
     int in, x = 0, y = 0;
     printf("%s6n", __prefix);
 
@@ -108,8 +108,8 @@ static const void __whereis_xy(int &__x, int &__y) {
     }
 
     /* Store and assign the cursor position */
-    __x = x;
-    __y = y;
+    *__x = x;
+    *__y = y;
 }
 
 
@@ -124,7 +124,7 @@ static const void __whereis_xy(int &__x, int &__y) {
  *
  * @since      0.1.0
  */
-const void gotoxy(const int __x, const int __y) {
+void gotoxy(const int __x, const int __y) {
     printf("%s%d;%df", __prefix, __y, __x);
 }
 
@@ -146,7 +146,7 @@ const void gotoxy(const int __x, const int __y) {
  *
  * @since 0.1.0
  */
-const void clrscr() {
+void clrscr() {
     printf("%s0m%s1J%s1;1f", __prefix, __prefix, __prefix);
 }
 

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -160,6 +160,8 @@ void clrscr() {
  * @return      Returns the pushed-back character on success, or `EOF` on failure.
  *
  * @since       0.1.0
+ * @see         #getch()
+ * @see         #getche()
  */
 const int ungetch(const int __c) {
     return ungetc(__c, stdin);
@@ -172,9 +174,25 @@ const int ungetch(const int __c) {
  * @return Returns the character read from the standard input.
  *
  * @since  0.1.0
+ * @see    #getche()
+ * @see    #ungetch(int)
  */
 const int getch() {
     return __getch(0);  /* 0 means no echo */
+}
+
+/**
+ * @brief Reads a single character from the standard input and then echoing it.
+ * This function reads a single character from the standard input and then echoing it.
+ *
+ * @return Returns the character read from the standard input.
+ *
+ * @since  0.1.0
+ * @see    #getch()
+ * @see    #ungetch(int)
+ */
+const int getche() {
+    return __getch(1);  /* non-zero means with echo */
 }
 
 #endif /* CONIO_LT_H_ */


### PR DESCRIPTION
## What's Changed
- Refactor and remake all functions and turn it into **C** code.
- Remove the `putchar` function to prevent conflicting with `putchar` in `stdio.h` library.
  > **Note** Replaced by `putch(int)` function.
- Update the documentation.

## Summary
This refactor change will make the `conio_lt.h` no longer use `g++` (**C++** compiler) command to compile the program that uses this library, because all functions have been changed into **C** code and make it readable by adding docs comment on each function.
This changes has been tested using `clang v15.0.7` on **Linux** system and doesn't occurs any error during test.
