### PR TITLE
Introduce new functions and enhancements

### DIFF
--- a/conio_lt.h
+++ b/conio_lt.h
@@ -265,11 +265,29 @@ const cpos_t wherex(void) {
  *
  * @since  0.1.0
  */
-const cpos_t wherey() {
+const cpos_t wherey(void) {
     cpos_t __x = 0, __y = 0;
     __whereis_xy(&__x, &__y);
 
     return __y;  /* only return the Y-coordinate */
+}
+
+/**
+ * @brief Retrieves the current X and Y coordinates of the cursor on the terminal screen.
+ *
+ * This function stores the current X-coordinate in the variable pointed
+ * to by `__x`, and the Y-coordinate in the variable pointed to by `__y`.
+ *
+ * To use this function, provide the addresses of variables for X and Y
+ * to store the coordinates.
+ *
+ * @param[in,out] __x  Pointer to the variable where the X-coordinate will be stored.
+ * @param[in,out] __y  Pointer to the variable where the Y-coordinate will be stored.
+ *
+ * @since 0.2.0.
+ */
+void wherexy(cpos_t* __x, cpos_t* __y) {
+    __whereis_xy(__x, __y);
 }
 
 /**

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -51,9 +51,8 @@
 #include <fcntl.h>
 #include <termios.h>
 
-#define  cpos_t  unsigned int  /**< An abbreviation from Cursor Position Type.
-                                    Custom defined type to represent the
-                                    cursor position type.
+typedef unsigned int  cpos_t;  /**< An abbreviation from Cursor Position Type.
+                                    Custom type definition to represent the cursor position.
                                 */
 
 static const char* __prefix = "\033[";  /**< Prefix for control sequences. Internal use only. */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -28,6 +28,8 @@
  *  - rstscr()
  *  - getch()
  *  - getche()
+ *  - gotox(cpos_t)
+ *  - gotoy(cpos_t)
  *  - gotoxy(cpos_t, cpos_t)
  *  - putch(int)
  *  - ungetch(int)
@@ -313,6 +315,42 @@ void wherexy(cpos_t* __x, cpos_t* __y) {
 const int putch(const int __chr) {
     printf("%c", __chr);
     return __chr;
+}
+
+/**
+ * @brief Sets the cursor position to the specified X-coordinate,
+ *        maintaining the current Y-coordinate.
+ *
+ * This function serves as an alias for `gotoxy(x, wherey())`. It allows
+ * for flexible cursor manipulation by allowing the user to set the
+ * X-coordinate while keeping the current Y-coordinate unchanged.
+ *
+ * @param __x  The desired X-coordinate to set the cursor to.
+ *
+ * @since 0.2.0
+ * @see   #gotoy(cpos_t)
+ * @see   #gotoxy(cpos_t, cpos_t)
+ */
+void gotox(const cpos_t __x) {
+    gotoxy(__x, wherey());
+}
+
+/**
+ * @brief Sets the cursor position to the specified Y-coordinate,
+ *        maintaining the current X-coordinate.
+ *
+ * This function serves as an alias for `gotoxy(wherex(), y)`. It provides
+ * flexibility in cursor positioning by allowing the user to set the
+ * Y-coordinate while keeping the current X-coordinate unchanged.
+ *
+ * @param __y  The desired Y-coordinate to set the cursor to.
+ *
+ * @since 0.2.0
+ * @see   #gotox(cpos_t)
+ * @see   #gotoxy(cpos_t, cpos_t)
+ */
+void gotoy(const cpos_t __y) {
+    gotoxy(wherex(), __y);
 }
 
 #endif /* CONIO_LT_H_ */

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -1,5 +1,5 @@
 /*======================================================================
- * conio_lt, a lite version of <conio.h> library for Unix-like systems.
+ * conio_lt, a lightweight version of <conio.h> library for Unix-like systems.
  * Copyright (C) 2023-2024 Ryuu Mitsuki
  *
  * This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,7 @@
 /**
  * @file conio_lt.h
  *
- * Similar like `<conio.h>`, but it is a lite version of `<conio.h>` library.
+ * Similar to `<conio.h>`, but it is a lite version of `<conio.h>` library.
  * Hope this can be useful for your project.
  *
  * Available APIs
@@ -33,6 +33,7 @@
  *  - ungetch(int)
  *  - wherex()
  *  - wherey()
+ *  - wherexy(cpos_t*, cpos_t*)
  *
  * @author   Ryuu Mitsuki
  * @version  0.2.0, 14 January 2024
@@ -57,9 +58,12 @@ static const char* __prefix = "\033[";  /**< Prefix for control sequences. Inter
 
 /**
  * @brief Reads a single character from the standard input with optional echo.
+ *
  * This function reads a single character from the standard input, allowing
  * for optional echo of the input character.
- * It uses the \c <termios.h> header and the \c tcgetattr and \c tcsetattr functions to modify the terminal settings.
+ *
+ * It uses the \c <termios.h> header and the \c tcgetattr and \c tcsetattr
+ * functions to modify the terminal settings.
  *
  * @param  __echo  A flag indicating whether to echo the input character
  *                 (non-zero value for echo, 0 for no echo).
@@ -92,12 +96,13 @@ static const int __getch(uint8_t __echo) {
 
 /**
  * @brief Retrieves the current cursor position on the terminal screen.
+ *
  * This function retrieves the current cursor position on the terminal screen.
  * It takes two integer references, \c __x and \c __y, as output parameters to store
  * the X and Y coordinates of the cursor, respectively.
  *
- * @param[out] __x  A reference to an integer to store the X-coordinate of the cursor.
- * @param[out] __y  A reference to an integer to store the Y-coordinate of the cursor.
+ * @param[in,out] __x  A reference to an integer to store the X-coordinate of the cursor.
+ * @param[in,out] __y  A reference to an integer to store the Y-coordinate of the cursor.
  *
  * @since           0.1.0
  */
@@ -249,6 +254,8 @@ const int getche(void) {
  * @return Returns the X-coordinate of the cursor.
  *
  * @since  0.1.0
+ * @see    #wherey(void)
+ * @see    #wherexy(cpos_t*, cpos_t*)
  */
 const cpos_t wherex(void) {
     cpos_t __x = 0, __y = 0;
@@ -264,6 +271,8 @@ const cpos_t wherex(void) {
  * @return Returns the Y-coordinate of the cursor.
  *
  * @since  0.1.0
+ * @see    #wherex(void)
+ * @see    #wherexy(cpos_t*, cpos_t*)
  */
 const cpos_t wherey(void) {
     cpos_t __x = 0, __y = 0;

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -1,25 +1,38 @@
+/*======================================================================
+ * conio_lt, a lite version of <conio.h> library for Unix-like systems.
+ * Copyright (C) 2023-2024 Ryuu Mitsuki
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *======================================================================*/
+
 /**
  * @file conio_lt.h
  *
- * Similar like 'conio.h', but it's a lite version of 'conio.h'.
- * I hope this can be useful for your project or something else.
+ * Similar like `<conio.h>`, but it is a lite version of `<conio.h>` library.
+ * Hope this can be useful for your project.
  *
- * List Functions
+ * Available APIs
  * --------------
- * <ul>
- *   <li> #clrscr()
- *   <li> #rstscr()
- *   <li> #getch()
- *   <li> #getche()
- *   <li> #gotoxy(int, int)
- *   <li> #putch(int)
- *   <li> #ungetch(int)
- *   <li> #wherex()
- *   <li> #wherey()
- * </ul>
- *
- * Created and developed by Ryuu Mitsuki
- * Copyright (c) 2023-2024 Ryuu Mitsuki
+ *  - clrscr()
+ *  - rstscr()
+ *  - getch()
+ *  - getche()
+ *  - gotoxy(cpos_t, cpos_t)
+ *  - putch(int)
+ *  - ungetch(int)
+ *  - wherex()
+ *  - wherey()
  *
  * @author   Ryuu Mitsuki
  * @version  0.2.0, 14 January 2024

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -1,21 +1,14 @@
 /**
  * @file conio_lt.h
  *
- * Copyright (c) 2023 Ryuu Mitsuki
- * Authored and developed by Ryuu Mitsuki
- *
- * @version  0.1.5, 2 July 2023
- *
- * Description
- * -------------
  * Similar like 'conio.h', but it's a lite version of 'conio.h'.
  * I hope this can be useful for your project or something else.
- * ------------
  *
  * List Functions
  * --------------
  * <ul>
  *   <li> #clrscr()
+ *   <li> #rstscr()
  *   <li> #getch()
  *   <li> #getche()
  *   <li> #gotoxy(int, int)
@@ -24,8 +17,12 @@
  *   <li> #wherex()
  *   <li> #wherey()
  * </ul>
- * --------------
  *
+ * Created and developed by Ryuu Mitsuki
+ * Copyright (c) 2023-2024 Ryuu Mitsuki
+ *
+ * @author   Ryuu Mitsuki
+ * @version  0.2.0, 14 January 2024
  */
 
 #ifndef CONIO_LT_H_
@@ -147,6 +144,33 @@ void gotoxy(const int __x, const int __y) {
  */
 void clrscr() {
     printf("%s0m%s1J%s1;1f", __prefix, __prefix, __prefix);
+}
+
+/**
+ * @brief Resets and clears the terminal screen.
+ *
+ * This function resets any text formatting or color attributes,
+ * clears the entire terminal screen, and moves the cursor to the
+ * top-left corner. It achieves this effect by sending the appropriate
+ * control sequences to the standard output using \c printf.
+ *
+ * The function uses the following control sequences:
+ *   - \c "\033[0m": Resets any text formatting or color attributes.
+ *   - \c "\033c": Resets and clears the entire terminal screen.
+ *
+ * By combining these control sequences in a single \c printf statement,
+ * the function achieves the effect of resetting and clearing the terminal
+ * screen.
+ *
+ * @note  This function prevents the screen from scrolling by clearing
+ *        the entire screen. If you only want to clear the screen without
+ *        preventing scrolling, consider using the \c clrscr() function.
+ *
+ * @since 0.2.0
+ * @see   #clrscr(void)
+ */
+void rstscr(void) {
+    printf("%s0m\033c", __prefix);  /* "\033[0m\033c" */
 }
 
 /**

--- a/tests/test_clrscr.c
+++ b/tests/test_clrscr.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include "../conio_lt.h"
+
+int main(void) {
+    puts("Test: getch, clrscr, rstscr");
+
+    printf("Press any key to start the test...");
+    getch();
+    printf("\n");
+
+    /* Make the terminal screen dirty */
+    for (int i = 1; i <= 70; i++) {
+        printf("%d\n", i);
+    }
+
+    /* Clear the terminal screen */
+    printf("clrscr: Press any key to clear the screen...");
+    getch();
+    clrscr();
+
+    /* Clear and reset the terminal screen */
+    printf("rstscr: Press any key to reset the screen...");
+    getch();
+    rstscr();
+
+    return 0;
+}

--- a/tests/test_coord.c
+++ b/tests/test_coord.c
@@ -16,5 +16,11 @@ int main(void) {
     /* Move the cursor back to its previous position */
     gotoxy(x, y);
     puts("Now I'm back");
+
+    printf("Current position: ");
+
+    /* Get current position of the cursor, then print to the console */
+    wherexy((cpos_t*) &x, (cpos_t*) &y);  /* Need conversion */
+    printf("X:%d Y:%d\n", x, y);
     return 0;
 }

--- a/tests/test_coord.c
+++ b/tests/test_coord.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include "../conio_lt.h"
+
+int main(void) {
+    puts("Test: gotoxy, wherex, wherey\n");
+
+    /* Store the current position, so that we can use it later.
+     * The actual returned type is `cpos_t` or `unsigned int`,
+     * but it is also possible being stored in `int` type.
+     */
+    int x = wherex(), y = wherey();
+
+    gotoxy(20, 1);  /* Move the cursor position to X:20 and Y:1 */
+    printf("Hi there (from coord: X20 Y1)");
+
+    /* Move the cursor back to its previous position */
+    gotoxy(x, y);
+    puts("Now I'm back");
+    return 0;
+}

--- a/tests/test_getch.c
+++ b/tests/test_getch.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include "../conio_lt.h"
+
+int main(void) {
+    puts("Test: getch, getche, putch\n");
+
+    /* Optional prompt */
+    printf("getch: Enter any key...");
+
+    /* Get character from input, you can store it to either
+     * `int` or `char` type. `getch` function will never echoing
+     * the input character from user to the console.
+     */
+    int val = getch();
+
+    /* Print the output to the console */
+    printf("\nEntered key: ");
+    putch(val);  /* Test putch */
+    printf("\nInteger value: %d", val);
+    printf("\nHex value: %x\n", val);
+
+    puts("\nAlmost similar to `getch`, but `getche` will echo "
+         "the input to the console.\n");
+
+    printf("getche: Enter any key... ");  /* Optional prompt */
+    /* `getche` function will echoing the input character
+     * from user to the console.
+     */
+    val = getche();
+
+    /* Print the output to the console */
+    printf("\nEntered key: ");
+    putch(val);  /* Test putch */
+    printf("\nInteger value: %d", val);
+    printf("\nHex value: %x\n", val);
+    return 0;
+}


### PR DESCRIPTION
## What's Changed

### Features

#### `rstscr` Function (7183aa6)

Added a new function called `rstscr` that resets the terminal screen without causing scrolling, providing enhanced functionality compared to `clrscr`.

https://github.com/mitsuki31/conio_lt/blob/54fd4b5ccdf019eb6329bcef1736395bb45af613/conio_lt.h#L202-L204

#### `wherexy` Function (bcec583)

Added a new function to ease the cursor coordinates retrieval, this function are intended for flexbility (especially for reusable variables that needs to get current coordinates more than once, but it _doesn't_ improve the speed during compilation.

This function takes two parameters to store both X and Y coordinate.

> [!NOTE]\
> This function only accepts `unsigned int` type or you can use the defined alias, `cpos_t`.

https://github.com/mitsuki31/conio_lt/blob/54fd4b5ccdf019eb6329bcef1736395bb45af613/conio_lt.h#L299-L301

### `gotox` Function (5cefdd2)

Added a new function to set the cursor position to the specified X-coordinate, while keeping the Y-coordinate unchanged.

https://github.com/mitsuki31/conio_lt/blob/54fd4b5ccdf019eb6329bcef1736395bb45af613/conio_lt.h#L333-L335

> [!NOTE]\
> This function is an alias for...
> ```c
> gotoxy(x, wherey());
> ```

### `gotoy` Function (5cefdd2)

Added a new function to set the cursor position to the specified Y-coordinate, while keeping the X-coordinate unchanged.

https://github.com/mitsuki31/conio_lt/blob/54fd4b5ccdf019eb6329bcef1736395bb45af613/conio_lt.h#L351-L353

> [!NOTE]\
> This function is an alias for...
> ```c
> gotoxy(wherex(), y);
> ```

### Improvements
  - **Memory Usage and Compilation Time (9b9f9a3):**\
  Refactored to slightly reduce memory usage and improve compilation time. Changed several types to appropriate ones and introduced a custom type, `cpos_t`, for cursor position representation (aliased from `unsigned int`).

https://github.com/mitsuki31/conio_lt/blob/54fd4b5ccdf019eb6329bcef1736395bb45af613/conio_lt.h#L53-L56

### Documentation
  - **License Notice and Improve Docs (58135a4, 100b421):**\
  Added license notice and improved documentation for `conio_lt.h` file.

### Test Environments
  - **Additional Test Suites (09c71b2, 4684fa6):**\
  Implemented several test suites to enhance testing coverage.

<details>
<summary>All commits</summary>

- 54fd4b5 - refactor: Change the type defintion to more safe
- 5cefdd2 - feat: Add new functions to provide flexibility
- 100b421 - docs: Improve the documentation of APIs
- 4684fa6 - test: Update the test suites to test new function
- bcec583 - feat: Add a new function to retrieve both coordinates of cursor
- 58135a4 - docs: Add license notice and improve file docs
- 09c71b2 - test: Add several test suites
- 9b9f9a3 - refactor: Slightly reduce memory usage and improvisation
- 7183aa6 - feat: Introduce a new function called `rstscr`

</details>

## Summary

These changes aim to enhance functionality, optimize resource usage, improve documentation, and bolster testing capabilities in the `conio_lt` project.

### New APIs

#### `rstscr`
```c
rstscr(void);
```

#### `wherexy`
```c
wherexy(cpos_t* x, cpos_t* y);
```

#### `gotox`
```c
gotox(cpos_t x);
```

#### `gotoy`
```c
gotoy(cpos_t y);
```

### Examples

#### `rstscr`

```c
/* ... */
rstscr();
```

#### `wherexy`
```c
/* You can either use the `unsigned int` (built-in) or
 * `cpos_t` (custom-defined) type.
 */
cpos_t x, y;
wherexy(&x, &y);  /* Must be address references */
```

#### `gotox`
```c
/* Move the X-coordinate to 20 */
gotox(20);
```

#### `gotoy`
```c
/* Move the Y-coordinate to 5 */
gotoy(5);
```