### PR TITLE
Fix Windows and C++ compatibility

### DIFF
--- a/.doxygenrc
+++ b/.doxygenrc
@@ -48,7 +48,7 @@ PROJECT_NAME           = "conio_lt"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.2.0
+PROJECT_NUMBER         = 0.3.0-beta
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -548,7 +548,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,
@@ -1188,14 +1188,14 @@ FORTRAN_COMMENT_AFTER  = 72
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # multi-line macros, enums or list initialized variables directly into the
 # documentation.
 # The default value is: NO.
 
-INLINE_SOURCES         = YES
+INLINE_SOURCES         = NO
 
 # Setting the STRIP_CODE_COMMENTS tag to YES will instruct doxygen to hide any
 # special comment blocks from generated source code fragments. Normal C, C++ and

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -57,6 +57,10 @@
 #ifndef CONIO_LT_H_
 #define CONIO_LT_H_
 
+/* Header Version */
+#undef  __CONIO_LT_VER__
+#define __CONIO_LT_VER__  0x030
+
 /* Standard IO header */
 #include <stdio.h>
 

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -354,6 +354,13 @@ static void __whereis_xy(cpos_t* __x, cpos_t* __y) {
  * This function moves the cursor on the terminal screen to the specified coordinates.
  * It takes two integer parameters, `x` and `y`, representing the X and Y coordinates respectively.
  *
+ * Example
+ * -------
+ * ```c
+ * // Move the cursor to the top-left
+ * gotoxy(1, 1);
+ * ```
+ *
  * @param[in] x  The X-coordinate to move the cursor to.
  * @param[in] y  The Y-coordinate to move the cursor to.
  *
@@ -392,10 +399,10 @@ void gotoxy(cpos_t const x, cpos_t const y) {
  *   - This function does not prevent the screen from scrolling. If you want to reset
  *     entire the screen, use the @ref rstscr(void) instead.
  *
- * @warning This function relies on system-specific commands and escape sequences, and
- *          its behavior may not be consistent across all terminals or environments.
- *          Usage in environments like **Cygwin** or **MSYS2** on Windows may use control
- *          sequences instead, but it might not behave as expected.
+ * @attention This function relies on system-specific commands and escape sequences, and
+ *            its behavior may not be consistent across all terminals or environments.
+ *            Usage in environments like **Cygwin** or **MSYS2** on Windows may use control
+ *            sequences instead, but it might not behave as expected.
  *
  * @since 0.1.0
  * @see   rstscr(void)
@@ -448,10 +455,10 @@ void clrscr(void) {
  *     consider using the @ref clrscr(void) function. But in Windows systems, both
  *     functions will behave the same due to use of `"cls"` command in both functions.
  *
- * @warning This function relies on system-specific commands and escape sequences, and
- *          its behavior may not be consistent across all terminals or environments.
- *          Usage in environments like **Cygwin** or **MSYS2** on Windows may use control
- *          sequences instead, but it might not behave as expected.
+ * @attention This function relies on system-specific commands and escape sequences, and
+ *            its behavior may not be consistent across all terminals or environments.
+ *            Usage in environments like **Cygwin** or **MSYS2** on Windows may use control
+ *            sequences instead, but it might not behave as expected.
  *
  * @since 0.2.0
  * @see   clrscr(void)
@@ -521,6 +528,12 @@ int getche(void) {
  * This function retrieves the current X-coordinate of the cursor on the terminal screen.
  * The returned coordinate value always positive value.
  *
+ * Example
+ * -------
+ * ```c
+ * cpos_t cur_x = wherex();
+ * ```
+ *
  * @return Returns the X-coordinate of the cursor.
  *
  * @since  0.1.0
@@ -539,6 +552,12 @@ cpos_t wherex(void) {
  *
  * This function retrieves the current Y-coordinate of the cursor on the terminal screen.
  * The returned coordinate value always positive value.
+ *
+ * Example
+ * -------
+ * ```c
+ * cpos_t cur_y = wherey();
+ * ```
  *
  * @return Returns the Y-coordinate of the cursor.
  *
@@ -562,6 +581,13 @@ cpos_t wherey(void) {
  * To use this function, provide the addresses of variables for X and Y
  * to store the coordinates.
  *
+ * Example
+ * -------
+ * ```c
+ * cpos_t cur_x, cur_y;
+ * wherexy(&cur_x, &cur_y);
+ * ```
+ *
  * @param[in,out] x  Pointer to the variable where the X-coordinate will be stored.
  * @param[in,out] y  Pointer to the variable where the Y-coordinate will be stored.
  *
@@ -582,16 +608,20 @@ void wherexy(cpos_t* x, cpos_t* y) {
  *
  * @since 0.1.0
  */
-int putch(int const __c) {
-    return putchar(__c);
+int putch(int const c) {
+    return putchar(c);
 }
 
 /**
  * @brief Sets the cursor position to the specified X-coordinate,
  *        maintaining the current Y-coordinate.
  *
- * This function serves as an alias for `gotoxy(x, wherey())`. It allows
- * for flexible cursor manipulation by allowing the user to set the
+ * This function serves as an alias for:
+ * ```c
+ * gotoxy(x, wherey());
+ * ```
+ *
+ * It allows for flexible cursor manipulation by allowing the user to set the
  * X-coordinate while keeping the current Y-coordinate unchanged.
  *
  * @param[in] x  The desired X-coordinate to set the cursor to.
@@ -600,16 +630,20 @@ int putch(int const __c) {
  * @see   gotoy(cpos_t)
  * @see   gotoxy(cpos_t, cpos_t)
  */
-void gotox(cpos_t const __x) {
-    gotoxy(__x, wherey());
+void gotox(cpos_t const x) {
+    gotoxy(x, wherey());
 }
 
 /**
  * @brief Sets the cursor position to the specified Y-coordinate,
  *        maintaining the current X-coordinate.
  *
- * This function serves as an alias for `gotoxy(wherex(), y)`. It provides
- * flexibility in cursor positioning by allowing the user to set the
+ * This function serves as an alias for:
+ * ```c
+ * gotoxy(wherex(), y);
+ * ```
+ * 
+ * It provides flexibility in cursor positioning by allowing the user to set the
  * Y-coordinate while keeping the current X-coordinate unchanged.
  *
  * @param[in] y  The desired Y-coordinate to set the cursor to.
@@ -618,8 +652,8 @@ void gotox(cpos_t const __x) {
  * @see   gotox(cpos_t)
  * @see   gotoxy(cpos_t, cpos_t)
  */
-void gotoy(cpos_t const __y) {
-    gotoxy(wherex(), __y);
+void gotoy(cpos_t const y) {
+    gotoxy(wherex(), y);
 }
 
 #ifdef __cplusplus

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -186,9 +186,21 @@ typedef int64_t                 ssize_t;
 #  include <termios.h>  /* POSIX header for terminal I/O control */
 #endif  /* _WIN32 || __WIN32__ || __MINGW32__ */
 
-
+/**
+ * @brief Enumeration representing the echo behavior for the @ref __getch function.
+ *
+ * This enum enhances readability and ensures that the intended behavior is clear
+ * when using the @ref __getch function to read characters from the terminal.
+ *
+ * @since 0.3.0
+ * @see   __getch(GETCH_ECHO)
+ */
+typedef enum {
+    GETCH_NO_ECHO = 0,   /**< Represents the option to read a character without echoing it to the terminal. */
+    GETCH_USE_ECHO = 1   /**< Represents the option to read a character with echoing it to the terminal. */
+} GETCH_ECHO;
 typedef unsigned int  cpos_t;              /**< An abbreviation from **Cursor Position Type**, represents the cursor position. */
-static const char *   __prefix = "\033[";  /**< Prefix of ANSI escape sequences. Internal use only. */
+static const char *   __prefix = "\033[";  /**< Prefix of ANSI escape sequences.\ **Internal use only**. */
 
 #ifdef __cplusplus
 extern "C" {
@@ -202,11 +214,11 @@ extern "C" {
  * where user input needs to be read without displaying the entered characters.
  *
  * This is designed for internal use only and it is used by these two API functions:
- *   - `getch()` - is an alias for `__getch(0)` (without echo)
- *   - `getche()` - is an alias for `__getch(1)` (with echo)
+ *   - `getch()` - is an alias for `__getch(GETCH_NO_ECHO)` (without echo)
+ *   - `getche()` - is an alias for `__getch(GETCH_USE_ECHO)` (with echo)
  *
- * @param  __echo  Flag indicating whether to echo the input (0 for no echo, any positive value for echo).
- * @return         The retrieved character from the standard input.
+ * @param[in] __echo  Flag indicating whether to echo the input, see @ref GETCH_ECHO enum.
+ * @return            The retrieved character from the standard input.
  *
  * @note This function is platform-dependent. On Unix systems, it uses `termios.h` header
  *       to customize the terminal settings, while on Windows, it manipulates the
@@ -217,7 +229,7 @@ extern "C" {
  *
  * @since 0.1.0
  */
-static const int __getch(uint8_t __echo) {
+static int __getch(GETCH_ECHO const __echo) {
     int __c;
 
 #if defined(__UNIX_PLATFORM) || defined(__UNIX_PLATFORM_ANDRO)

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -289,8 +289,8 @@ static int __getch(GETCH_ECHO const __echo) {
  *   - `wherexy(cpos_t*, cpos_t*)` - Retrieves the current both coordinates of the cursor position
  *                                   stored in provided pointer variables
  *
- * @param[out] __x  Pointer to a variable where the X-coordinate of the cursor will be stored.
- * @param[out] __y  Pointer to a variable where the Y-coordinate of the cursor will be stored.
+ * @param[in,out] __x  Pointer to a variable where the X-coordinate of the cursor will be stored.
+ * @param[in,out] __y  Pointer to a variable where the Y-coordinate of the cursor will be stored.
  *
  * @note For Unix-like systems, this function sends the ANSI escape sequence `"\033[6n"`
  *       to the terminal and parses the response to obtain cursor coordinates. On Windows,
@@ -348,15 +348,15 @@ static void __whereis_xy(cpos_t* __x, cpos_t* __y) {
  * @brief Moves the cursor to the specified coordinates on the terminal screen.
  *
  * This function moves the cursor on the terminal screen to the specified coordinates.
- * It takes two integer parameters, `__x` and `__y`, representing the X and Y coordinates respectively.
+ * It takes two integer parameters, `x` and `y`, representing the X and Y coordinates respectively.
  *
- * @param __x  The X-coordinate to move the cursor to.
- * @param __y  The Y-coordinate to move the cursor to.
+ * @param[in] x  The X-coordinate to move the cursor to.
+ * @param[in] y  The Y-coordinate to move the cursor to.
  *
- * @since      0.1.0
+ * @since 0.1.0
  */
-void gotoxy(const cpos_t __x, const cpos_t __y) {
-    printf("%s%u;%uf", __prefix, __y, __x);  /* "\033[{y};{x}f" */
+void gotoxy(cpos_t const x, cpos_t const y) {
+    printf("%s%u;%uf", __prefix, y, x);  /* "\033[{y};{x}f" */
 }
 
 /**
@@ -468,18 +468,17 @@ void rstscr(void) {
  * @brief Pushes a character back onto the input stream.
  *
  * This function pushes a character back onto the input stream.
- * It takes an integer parameter `__c`, representing the character to be pushed back.
+ * It takes an integer parameter `c`, representing the character to be pushed back.
  *
- * @param  __c  The character to be pushed back.
+ * @param[in] c  The character to be pushed back.
+ * @return       Returns the pushed-back character on success, or `EOF` on failure.
  *
- * @return      Returns the pushed-back character on success, or `EOF` on failure.
- *
- * @since       0.1.0
- * @see         getch(void)
- * @see         getche(void)
+ * @since 0.1.0
+ * @see   getch(void)
+ * @see   getche(void)
  */
-const int ungetch(const int __c) {
-    return ungetc(__c, stdin);
+int ungetch(int const c) {
+    return ungetc(c, stdin);
 }
 
 /**
@@ -493,8 +492,8 @@ const int ungetch(const int __c) {
  * @see    getche(void)
  * @see    ungetch(int)
  */
-const int getch(void) {
-    return __getch(0);  /* 0 means no echo */
+int getch(void) {
+    return __getch(GETCH_NO_ECHO);  /* GETCH_NO_ECHO means no echoing input */
 }
 
 /**
@@ -508,8 +507,8 @@ const int getch(void) {
  * @see    getch(void)
  * @see    ungetch(int)
  */
-const int getche(void) {
-    return __getch(1);  /* non-zero means with echo */
+int getche(void) {
+    return __getch(GETCH_USE_ECHO);  /* GETCH_USE_ECHO means with echoing input */
 }
 
 /**
@@ -524,7 +523,7 @@ const int getche(void) {
  * @see    wherey(void)
  * @see    wherexy(cpos_t*, cpos_t*)
  */
-const cpos_t wherex(void) {
+cpos_t wherex(void) {
     cpos_t __x = 0, __y = 0;
     __whereis_xy(&__x, &__y);
 
@@ -543,7 +542,7 @@ const cpos_t wherex(void) {
  * @see    wherex(void)
  * @see    wherexy(cpos_t*, cpos_t*)
  */
-const cpos_t wherey(void) {
+cpos_t wherey(void) {
     cpos_t __x = 0, __y = 0;
     __whereis_xy(&__x, &__y);
 
@@ -554,35 +553,33 @@ const cpos_t wherey(void) {
  * @brief Retrieves the current X and Y coordinates of the cursor on the terminal screen.
  *
  * This function stores the current X-coordinate in the variable pointed
- * to by `__x`, and the Y-coordinate in the variable pointed to by `__y`.
+ * to by `x`, and the Y-coordinate in the variable pointed to by `y`.
  *
  * To use this function, provide the addresses of variables for X and Y
  * to store the coordinates.
  *
- * @param[in,out] __x  Pointer to the variable where the X-coordinate will be stored.
- * @param[in,out] __y  Pointer to the variable where the Y-coordinate will be stored.
+ * @param[in,out] x  Pointer to the variable where the X-coordinate will be stored.
+ * @param[in,out] y  Pointer to the variable where the Y-coordinate will be stored.
  *
  * @since 0.2.0.
  */
-void wherexy(cpos_t* __x, cpos_t* __y) {
-    __whereis_xy(__x, __y);
+void wherexy(cpos_t* x, cpos_t* y) {
+    __whereis_xy(x, y);
 }
 
 /**
  * @brief Writes a character to the standard output.
  *
  * This function writes a character to the standard output.
- * It takes an integer parameter `__chr`, representing the character to be written.
+ * It takes an integer parameter `c`, representing the character to be written.
  *
- * @param  __chr  The character to be written.
+ * @param[in] c  The character to be written.
+ * @return       Returns the written character as an integer.
  *
- * @return        Returns the written character as an integer.
- *
- * @since         0.1.0
+ * @since 0.1.0
  */
-const int putch(const int __chr) {
-    printf("%c", __chr);
-    return __chr;
+int putch(int const __c) {
+    return putchar(__c);
 }
 
 /**
@@ -593,13 +590,13 @@ const int putch(const int __chr) {
  * for flexible cursor manipulation by allowing the user to set the
  * X-coordinate while keeping the current Y-coordinate unchanged.
  *
- * @param __x  The desired X-coordinate to set the cursor to.
+ * @param[in] x  The desired X-coordinate to set the cursor to.
  *
  * @since 0.2.0
  * @see   gotoy(cpos_t)
  * @see   gotoxy(cpos_t, cpos_t)
  */
-void gotox(const cpos_t __x) {
+void gotox(cpos_t const __x) {
     gotoxy(__x, wherey());
 }
 
@@ -611,13 +608,13 @@ void gotox(const cpos_t __x) {
  * flexibility in cursor positioning by allowing the user to set the
  * Y-coordinate while keeping the current X-coordinate unchanged.
  *
- * @param __y  The desired Y-coordinate to set the cursor to.
+ * @param[in] y  The desired Y-coordinate to set the cursor to.
  *
  * @since 0.2.0
  * @see   gotox(cpos_t)
  * @see   gotoxy(cpos_t, cpos_t)
  */
-void gotoy(const cpos_t __y) {
+void gotoy(cpos_t const __y) {
     gotoxy(wherex(), __y);
 }
 

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -393,7 +393,7 @@ void gotoxy(cpos_t const x, cpos_t const y) {
 }
 
 /**
- * @brief Clears the terminal screen.
+ * @brief Clears without resetting the terminal screen.
  *
  * This function provides a platform-dependent way to clear the terminal screen.
  * On Windows, it uses the system command `"cls"` for Command Prompt or PowerShell.
@@ -411,15 +411,14 @@ void gotoxy(cpos_t const x, cpos_t const y) {
  * By combining these control sequences in a single `printf` statement,
  * the function achieves the effect of clearing the terminal screen.
  *
- * @note
- *   - On Unix-like systems, ANSI escape sequences are used. Some terminals may not
- *     support these sequences, affecting the clearing functionality.
- *   - The function's behavior may differ in environments like **Cygwin** or **MSYS2**
- *     on Windows, and users are encouraged to be aware of such variations. In such
- *     environments, the function will use the control sequences to clear the terminal
- *     screen instead of using the `"cls"` command.
- *   - This function does not prevent the screen from scrolling. If you want to reset
- *     entire the screen, use the @ref rstscr(void) instead.
+ * @note - On Unix-like systems, ANSI escape sequences are used. Some terminals may not
+ *         support these sequences, affecting the clearing functionality.
+ *       - The function's behavior may differ in environments like **Cygwin** or **MSYS2**
+ *         on Windows, and users are encouraged to be aware of such variations. In such
+ *         environments, the function will use the control sequences to clear the terminal
+ *         screen instead of using the `"cls"` command.
+ *       - This function does not prevent the screen from scrolling. If you want to reset
+ *         entire the screen, use the @ref rstscr(void) instead.
  *
  * @attention This function relies on system-specific commands and escape sequences, and
  *            its behavior may not be consistent across all terminals or environments.
@@ -465,17 +464,16 @@ void clrscr(void) {
  * the function achieves the effect of resetting and clearing the terminal
  * screen.
  *
- * @note
- *   - On Unix-like systems, ANSI escape sequences are used. Some terminals may not
- *     support these sequences, affecting the clearing functionality.
- *   - The function's behavior may differ in environments like **Cygwin** or **MSYS2**
- *     on Windows, and users are encouraged to be aware of such variations. In such
- *     environments, the function will use the control sequences to reset the terminal
- *     screen instead of using the `"cls"` command.
- *   - This function prevents the screen from scrolling by clearing the entire screen.
- *     If you only want to clear the screen without preventing scrolling and resetting,
- *     consider using the @ref clrscr(void) function. But in Windows systems, both
- *     functions will behave the same due to use of `"cls"` command in both functions.
+ * @note - On Unix-like systems, ANSI escape sequences are used. Some terminals may not
+ *         support these sequences, affecting the clearing functionality.
+ *       - The function's behavior may differ in environments like **Cygwin** or **MSYS2**
+ *         on Windows, and users are encouraged to be aware of such variations. In such
+ *         environments, the function will use the control sequences to reset the terminal
+ *         screen instead of using the `"cls"` command.
+ *       - This function prevents the screen from scrolling by clearing the entire screen.
+ *         If you only want to clear the screen without preventing scrolling and resetting,
+ *         consider using the @ref clrscr(void) function. But in Windows systems, both
+ *         functions will behave the same due to use of `"cls"` command in both functions.
  *
  * @attention This function relies on system-specific commands and escape sequences, and
  *            its behavior may not be consistent across all terminals or environments.
@@ -515,9 +513,16 @@ int ungetch(int const c) {
 }
 
 /**
- * @brief Reads a single character from the standard input without echoing it.
+ * @brief Reads a single character from the standard input without buffer.
  *
- * This function reads a single character from the standard input without echoing it.
+ * This function reads a single character from the standard input without buffer.
+ *
+ * Example
+ * -------
+ * ```c
+ * // You can either use `char` or `int`, it is up to your preference
+ * char c = getch();  // Wait until user input a character
+ * ```
  *
  * @return Returns the character read from the standard input.
  *
@@ -530,9 +535,16 @@ int getch(void) {
 }
 
 /**
- * @brief Reads a single character from the standard input and then echoing it.
+ * @brief Reads a single character from the standard input with buffer.
  *
- * This function reads a single character from the standard input and then echoing it.
+ * This function reads a single character from the standard input with buffer.
+ *
+ * Example
+ * -------
+ * ```c
+ * // You can either use `char` or `int`, it is up to your preference
+ * char c = getche();  // Wait until user input a character
+ * ```
  *
  * @return Returns the character read from the standard input.
  *

--- a/conio_lt.h
+++ b/conio_lt.h
@@ -19,9 +19,18 @@
 /**
  * @file conio_lt.h
  *
- * `conio_lt` library is a lightweight adaptation of the `<conio.h>` library
- * designed for Unix-like systems. This project aims to bring these functionalities
- * to Unix-like systems and Borland C++, especially for legacy version of Borland C++.
+ * @brief `conio_lt` is a lightweight adaptation of the `<conio.h>` library,
+ *        designed specifically for Unix-like systems and Termux on Android.
+ *
+ * This library aims to bring console manipulation functionalities to Unix-like
+ * environments, providing a subset of features found in `<conio.h>`. It is tailored
+ * for Unix-like systems, and its usage on Windows is not guaranteed to behave as
+ * expected. Users are advised to exercise caution when using this library on
+ * non-Unix environments.
+ *
+ * @note If you intend to run Unix-like commands on a Windows system, consider using
+ *       [MSYS2](https://msys2.org) to provide a Bash shell environment. Keep in mind
+ *       this approach may not fully replicate Unix-like behaviors on Windows.
  *
  * Available APIs
  * --------------
@@ -174,20 +183,27 @@ extern "C" {
 #endif   /* __cplusplus */
 
 /**
- * @brief Reads a single character from the standard input with optional echo.
+ * @brief Retrieves a single character from the standard input without echoing.
  *
- * This function reads a single character from the standard input, allowing
- * for optional echo of the input character.
+ * This function retrieves a character from the standard input without echoing it
+ * to the console. It is designed for use in console-based applications
+ * where user input needs to be read without displaying the entered characters.
  *
- * It uses the `<termios.h>` header and the `tcgetattr` and `tcsetattr`
- * functions to modify the terminal settings.
+ * This is designed for internal use only and it is used by these two API functions:
+ *   - `getch()` - is an alias for `__getch(0)` (without echo)
+ *   - `getche()` - is an alias for `__getch(1)` (with echo)
  *
- * @param  __echo  A flag indicating whether to echo the input character
- *                 (non-zero value for echo, zero for *no* echo).
+ * @param  __echo  Flag indicating whether to echo the input (0 for no echo, any positive value for echo).
+ * @return         The retrieved character from the standard input.
  *
- * @return         Returns the character read from the standard input.
+ * @note This function is platform-dependent. On Unix systems, it uses `termios.h` header
+ *       to customize the terminal settings, while on Windows, it manipulates the
+ *       console mode using Windows API (`windows.h`).
  *
- * @since          0.1.0
+ * @warning This function may not behave as expected on non-terminal input streams.
+ *          It is intended for console-based applications.
+ *
+ * @since 0.1.0
  */
 static const int __getch(uint8_t __echo) {
     int __c;
@@ -233,16 +249,31 @@ static const int __getch(uint8_t __echo) {
 
 
 /**
- * @brief Retrieves the current cursor position on the terminal screen.
+ * @brief Retrieves the current coordinates of the cursor on the terminal screen.
  *
- * This function retrieves the current cursor position on the terminal screen.
- * It takes two integer references, `__x` and `__y`, as output parameters to store
- * the X and Y coordinates of the cursor, respectively.
+ * This function is designed to work on both Unix-like systems and Windows. On Unix-like
+ * systems, it uses ANSI escape sequences to query the cursor position. On Windows, it
+ * utilizes the Windows Console API to obtain the cursor coordinates.
  *
- * @param[out] __x  A reference to an integer to store the X-coordinate of the cursor.
- * @param[out] __y  A reference to an integer to store the Y-coordinate of the cursor.
+ * This function is designed for internal use only and it's being used by these API functions:
+ *   - `wherex()`                  - Retrieves the current X-coordinate of the cursor position
+ *   - `wherey()`                  - Retrieves the current Y-coordinate of the cursor position
+ *   - `wherexy(cpos_t*, cpos_t*)` - Retrieves the current both coordinates of the cursor position
+ *                                   stored in provided pointer variables
  *
- * @since           0.1.0
+ * @param[out] __x  Pointer to a variable where the X-coordinate of the cursor will be stored.
+ * @param[out] __y  Pointer to a variable where the Y-coordinate of the cursor will be stored.
+ *
+ * @note For Unix-like systems, this function sends the ANSI escape sequence `"\033[6n"`
+ *       to the terminal and parses the response to obtain cursor coordinates. On Windows,
+ *       it uses the Windows Console API to get the cursor position.
+ *
+ * @warning This function may not work correctly in all terminal emulators or environments,
+ *          especially if the terminal does not support ANSI escape sequences. Ensure that your
+ *          target environment supports the necessary features.
+ *
+ * @since 0.1.0
+ * @see   wherexy(cpos_t*, cpos_t*)
  */
 static void __whereis_xy(cpos_t* __x, cpos_t* __y) {
     cpos_t x = 0, y = 0;  /* Variables to hold the coordinates */


### PR DESCRIPTION
## Overview

This branch addresses various improvements and refinements to the `conio_lt` library, specifically focusing on enhancing the documentation for key APIs, refactoring internal functions, and ensuring compatibility across different platforms with main focus on Windows platform and add support to C++ compilers. Noteable changes include:

- Windows Console API refinements and C++ compiler support improvements.
- Added compatibility for non-POSIX terminals in every APIs function.
- Improved Doxygen documentation options and page clarity.
- Enhanced function documentation with examples.
- Defined a new macro to represent the header version.
- Introduced an enumeration for `__getch` parameter values called `GETCH_ECHO`.

## Changes Made

### Compatibility and C++ Support

  - Added C++ support using the `extern` statement to prevent name-mangling.
  - Refactored all functions to compatible with Windows systems.
  - Enhanced clarity in the `clrscr` and `rstscr` functions for Windows compatibility.
  - Warns users if compiling with pre-C99 (C) or pre-C++11 (C++) compilers.
  - Imports headers based on platform-specific availability.
  - Utilized `windows.h` header for Windows-specific systems.
  - Defined a minor replacement for the `unistd.h` header for Windows systems.
  - Conditionally imported `stdint.h` based on compiler versions.

### Features and Improvements

  - Defined a new macro represents the current version of the header in hexadecimal value (e.g., `0x030` represents 0.3.0).

### Documentation Refinement

  - Detailed refinement of documentation for all members (including static ones), providing a more comprehensive overview of their functionality.
  - Added an example for several APIs function to assist users undertanding the usage of various APIs.
  - Updated Doxygen configuration (`.doxygenrc`) for version and documentation improvements.

<details>
<summary>All commits</summary>

- 67e3fed - chore(docs): Change some options in `.doxygenrc`
- df1e82c - docs: Improve the function docs and example addition
- 89de1b1 - feat: Add support for non-POSIX terminal on `gotoxy`
- 3c12dcd - docs: Add an example for several APIs
- 1e8788e - feat: Define new macro to represent the header version
- e47c9f7 - docs: Improve the documentation and rename the parameters
- 8d78e3f - feat: Add new enumeration for `__getch` paramater's value
- 8d9c0f4 - feat: Clear screen functions now Windows-compatible
- 53bb10f - refactor: Windows Console API refinements and some refactors

</details>

## Summary

This pull request elevates the project's documentation quality, expands compatibility with Windows systems and C++, and refactors internal functions for enhanced code structure and cross-platform adaptability. Users are now provided with compiler compatibility warnings, ensuring seamless integration. The `conio_lt` library gains improved versatility with better support for non-POSIX terminals on Windows, making it accessible to a broader user base.

> [!NOTE]\
> It is highly recommended to compile using C99 compilers or later. For C++, it is advisable to use C++11 compilers or later since the `<stdint.h>` header file is introduced in the C99 standard library. Warnings will be issued if pre-C99 or pre-C++11 (for C++) compilers are detected.
> 
> For further details, refer to the [Wiki Books | C Programming/stdint.h](https://en.m.wikibooks.org/wiki/C_Programming/stdint.h) page.
