### PR TITLE
fix: Resolve typedefs redefinition issue

### DIFF
--- a/conio_lt.h
+++ b/conio_lt.h
@@ -49,7 +49,7 @@
  *
  * @author    Ryuu Mitsuki
  * @version   0.3.0-beta
- * @date      25 Jan 2024
+ * @date      26 Jan 2024
  * @copyright &copy; 2023 - 2024 Ryuu Mitsuki.
  *            Licensed under the GNU General Public License 3.0.
  */
@@ -221,8 +221,8 @@ typedef unsigned int            uint32_t;  /* U 32-bit */
  * @see   __getch(GETCH_ECHO)
  */
 typedef enum {
-    GETCH_NO_ECHO = 0,   /**< Represents the option to read a character without echoing it to the terminal. */
-    GETCH_USE_ECHO = 1   /**< Represents the option to read a character with echoing it to the terminal. */
+    GETCH_NO_ECHO,   /**< Represents the option to read a character without echoing it to the terminal. */
+    GETCH_USE_ECHO   /**< Represents the option to read a character with echoing it to the terminal. */
 } GETCH_ECHO;
 
 /**


### PR DESCRIPTION
## Overview

This pull request aims to improve the `conio_lt` header's code structure, resolve `typedef`s redefinition issues, and enhance cross-platform compatibility. Users are advised to adopt modern compilers to leverage optimal features and prevent potential compatibility challenges.

> [!NOTE]\
> The replacement for `stdint.h` is now triggered only with the `_CONIO_LT_DEF_STDINT` macro, resolving redefinition issues on MSYS2 (Windows). [See Notes](#notes), for further information.

## Changes Made

- c144f95 - Remove unnecessary assignment of enumerator values.

- e4eaeaf - Refactor `cpos_t` type and variable replacement
  - `cpos_t` (**Cursor Position**) type is now aliased from `signed short` on Unix systems and from `SHORT` using the Windows API (`windows.h`) on Windows.
  - Replaced the `__prefix` variable with the `ESC` macro, which is now declared as a public API.
  - Refactored functions using the `__prefix` variable due to the variable replacement.

- 13514b6 - Improve and refactor header imports for cross-platform compatibility
  - Improved statements to import the `stdint.h` header on specific platforms.
  - Enhanced warning messages for the use of C99 and C++11 compilers.
  - Modified the replacement for `stdint.h` to trigger only if the `_CONIO_LT_DEF_STDINT` macro is defined, avoiding redefinition issues.
  - Changed the replacement for `unistd.h` on Windows to use a macro checker (`#ifndef`) before defining, preventing redefinition issues.
  - Added documentation for the macro representing the header version.
## <a name="notes"/> Notes

The replacement for `stdint.h` has been adjusted to address redefinition issues, now triggered only if the `_CONIO_LT_DEF_STDINT` macro is defined. This macro can be defined before importing the `conio_lt.h` header or using C flags in command-line arguments. Example:

```bash
$ gcc ... -std=c89 -D_CONIO_LT_DEF_STDINT
```

This change addressed the unexpected typedef issues on MSYS2 (Windows). It ensures compatibility with pre-C99 or pre-C++11 compilers, and users are encouraged to adopt C99 (or C++11 for C++) compilers and/or later versions for a smoother experience.
