### PR TITLE
fix(c++): Resolve inappropriate argument type on function call

### DIFF
--- a/conio_lt.h
+++ b/conio_lt.h
@@ -375,16 +375,16 @@ static void __whereis_xy(cpos_t* __x, cpos_t* __y) {
      * nor '0x5B' ('['), then return (leaving the '__x' and '__y' references
      * unmodified) because it was unable to get current position of cursor.
      */
-    if (__getch(0) != 0x1B ^ __getch(0) != 0x5B) {
+    if (__getch(GETCH_NO_ECHO) != 0x1B ^ __getch(GETCH_NO_ECHO) != 0x5B) {
         return;
     }
 
     int temp;
-    while ((temp = __getch(0)) != 0x3B /* ';' */) {
+    while ((temp = __getch(GETCH_NO_ECHO)) != 0x3B /* ';' */) {
         y = y * 10 + (temp - '0');
     }
 
-    while ((temp = __getch(0)) != 0x52 /* 'R' */) {
+    while ((temp = __getch(GETCH_NO_ECHO)) != 0x52 /* 'R' */) {
         x = x * 10 + (temp - '0');
     }
 #endif  /* __WIN_PLATFORM_32 || __MINGWC_32 */


### PR DESCRIPTION
## Summary

This pull request addressed the issue in C++ compiler due to inappropriate argument type when calling the `__getch` function.

The details errors may looks like this:

```
./conio_lt.h:378:9: error: no matching function for call to '__getch'
    if (__getch(0) != 0x1B ^ __getch(0) != 0x5B) {
        ^~~~~~~
./conio_lt.h:283:12: note: candidate function not viable: no known conversion from 'int' to 'const GETCH_ECHO' for 1st argument
static int __getch(GETCH_ECHO const __echo) {
           ^
./conio_lt.h:378:30: error: no matching function for call to '__getch'
    if (__getch(0) != 0x1B ^ __getch(0) != 0x5B) {
                             ^~~~~~~
./conio_lt.h:283:12: note: candidate function not viable: no known conversion from 'int' to 'const GETCH_ECHO' for 1st argument
static int __getch(GETCH_ECHO const __echo) {
           ^
./conio_lt.h:383:20: error: no matching function for call to '__getch'
    while ((temp = __getch(0)) != 0x3B /* ';' */) {
                   ^~~~~~~
./conio_lt.h:283:12: note: candidate function not viable: no known conversion from 'int' to 'const GETCH_ECHO' for 1st argument
static int __getch(GETCH_ECHO const __echo) {
           ^
./conio_lt.h:387:20: error: no matching function for call to '__getch'
    while ((temp = __getch(0)) != 0x52 /* 'R' */) {
                   ^~~~~~~
./conio_lt.h:283:12: note: candidate function not viable: no known conversion from 'int' to 'const GETCH_ECHO' for 1st argument
static int __getch(GETCH_ECHO const __echo) {
           ^
1 warning and 4 errors generated.
```

This issue was caused by not using the appropriate argument type, but instead using the native integer type to call the `__getch` function. The issue has now been **fixed** and uses the correct argument type, the `GETCH_ECHO` type.